### PR TITLE
Handle date ordinals such as Sunday 25th June 1989

### DIFF
--- a/godate.go
+++ b/godate.go
@@ -67,6 +67,7 @@ var (
 	monthsShort     = []string{"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"}
 	daysOfWeekShort = []string{"mon", "tue", "wed", "thu", "fri", "sat", "sun"}
 	daysOfWeek      = []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
+	dateOrdinals    = []string{"st", "nd", "rd", "th"}
 
 	standardDateFormats = []string{
 		time.RFC1123,
@@ -187,16 +188,24 @@ func ParseInLocation(s string, loc *time.Location) (time.Time, error) {
 // and if successful, returns the timestamp and the layout of the
 // string.
 func ParseAndGetLayout(date string) (time.Time, string, error) {
+
 	if len(strings.TrimSpace(date)) == 0 {
 		return time.Time{}, "", errors.New("Empty string cannot be parsed to date")
 	}
+
 	// Check standard date formats first.
 	for _, f := range standardDateFormats {
 		if t, err := time.Parse(f, date); err == nil {
 			return t, f, nil
 		}
 	}
+
+	// Remove Date Ordinals
+	re := regexp.MustCompile("(?i)([1-9]+)(" + strings.Join(dateOrdinals, "|") + ")")
+	date = re.ReplaceAllString(date, "$1")
+
 	s := strings.ToLower(date)
+
 	layout := &bytes.Buffer{}
 	prefix := getPrefix(s)
 	layout.WriteString(prefix)

--- a/godate_test.go
+++ b/godate_test.go
@@ -50,15 +50,59 @@ func TestDates(t *testing.T) {
 
 		"19890625",
 		"890625",
+
+		"Sunday 25th June 1989",
 	}
 
 	for _, date := range tests {
 		d, err := Parse(date)
 		if err != nil {
-			t.Errorf("Error prasing %q: %v", date, err)
+			t.Errorf("Error parsing %q: %v", date, err)
 		} else if d != correct {
 			t.Errorf("Dates for %q did not match:\n%v (actual)\n%v (expected)", date, d, correct)
 		}
+	}
+
+	// Testing Other Date Ordinals
+
+	// Test st date ordinal
+	correct = time.Date(1989, 8, 1, 0, 0, 0, 0, time.UTC)
+	date := "Tuesday 1st August 1989"
+	d, err := Parse(date)
+	if err != nil {
+		t.Errorf("Error parsing %q: %v", date, err)
+	} else if d != correct {
+		t.Errorf("Dates for %q did not match:\n%v (actual)\n%v (expected)", date, d, correct)
+	}
+
+	// Test nd date ordinal
+	correct = time.Date(1989, 8, 2, 0, 0, 0, 0, time.UTC)
+	date = "Wednesday 2nd August 1989"
+	d, err = Parse(date)
+	if err != nil {
+		t.Errorf("Error parsing %q: %v", date, err)
+	} else if d != correct {
+		t.Errorf("Dates for %q did not match:\n%v (actual)\n%v (expected)", date, d, correct)
+	}
+
+	// Test rd date ordinal
+	correct = time.Date(1989, 8, 3, 0, 0, 0, 0, time.UTC)
+	date = "Wednesday 3rd August 1989"
+	d, err = Parse(date)
+	if err != nil {
+		t.Errorf("Error parsing %q: %v", date, err)
+	} else if d != correct {
+		t.Errorf("Dates for %q did not match:\n%v (actual)\n%v (expected)", date, d, correct)
+	}
+
+	// Test th date ordinal
+	correct = time.Date(1989, 8, 4, 0, 0, 0, 0, time.UTC)
+	date = "Wednesday 4th August 1989"
+	d, err = Parse(date)
+	if err != nil {
+		t.Errorf("Error parsing %q: %v", date, err)
+	} else if d != correct {
+		t.Errorf("Dates for %q did not match:\n%v (actual)\n%v (expected)", date, d, correct)
 	}
 
 	// Just month and year


### PR DESCRIPTION
Strip out date ordinals from the date, add tests for the different ordinal types and fix a typo in the test error message